### PR TITLE
updating repos to deploy artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Schema
 
-## Version 0.12.0
+## Version 0.12.1
 
 The Schema repository holds the protocol buffer message schemas used to exchange data between systems.
 The commands below will create Protobuf classes for use in iOS, Python, and JVM (Clojure, Java, Android) runtimes.
@@ -22,6 +22,16 @@ This will put a schema jar in your local maven repo
 ```
 sh script/java.sh
 ```
+
+After running the above command, if you want to publish the artifact,
+
+```
+cd java
+mvn deploy
+```
+> Note: your ~/.m2/settings.xml must be setup with authentication
+> credentials required to publish to the Boundless maven repo
+
 
 ## Objective-C
 This will build to a folder called `objc_build` in the root dir

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.boundlessgeo</groupId>
   <artifactId>schema</artifactId>
-  <version>0.12</version>
+  <version>0.12.2-SNAPSHOT</version>
   <dependencies>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -17,14 +17,14 @@
   </dependencies>
   <distributionManagement>
     <repository>
-        <id>central</id>
-        <name>repo.boundlessgeo.com-releases</name>
-        <url>http://repo.boundlessgeo.com/artifactory/release</url>
+        <id>boundlessgeo-release</id>
+        <name>Boundless Releases</name>
+        <url>https://repo.boundlessgeo.com/release</url>
     </repository>
     <snapshotRepository>
-        <id>snapshots</id>
-        <name>repo.boundlessgeo.com-snapshots</name>
-        <url>http://repo.boundlessgeo.com/artifactory/release</url>
+        <id>boundlessgeo-snapshot</id>
+        <name>Boundless Snapshots</name>
+        <url>https://repo.boundlessgeo.com/snapshot</url>
     </snapshotRepository>
   </distributionManagement>
 </project>


### PR DESCRIPTION
I updated the repos to use Boundless' official release and snapshot repositories.  I also changed the id of each repo to match the config I have in my `settings.xml`, which is where you need to setup authentication information if you want to publish artifacts using `mvn deploy`.
> Note: I needed to use the encrypted password generated from the artifactory site so that I could deploy

* I updated the schema artifact version to use [semver](http://semver.org/), starting with the 0.12.1 release